### PR TITLE
Keystore timeouts

### DIFF
--- a/app/src/main/kotlin/cloud/keyspace/android/CryptoUtilities.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/CryptoUtilities.kt
@@ -67,7 +67,8 @@ class CryptoUtilities(
     val KEYRING_NAME = MasterKey.DEFAULT_MASTER_KEY_ALIAS
 
     private var XCHACHA_POLY1305_NONCE_BYTES = 24
-    var DEFAULT_AUTHENTICATION_DELAY = 5
+    // Keystore timeout
+    var DEFAULT_AUTHENTICATION_DELAY = 30
 
     fun ByteArray.toHexString(): String = joinToString(separator = "") { eachByte -> "%02x".format(eachByte) }
 

--- a/app/src/main/kotlin/cloud/keyspace/android/CryptoUtilities.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/CryptoUtilities.kt
@@ -67,7 +67,7 @@ class CryptoUtilities(
     val KEYRING_NAME = MasterKey.DEFAULT_MASTER_KEY_ALIAS
 
     private var XCHACHA_POLY1305_NONCE_BYTES = 24
-    var DEFAULT_AUTHENTICATION_DELAY = 30
+    var DEFAULT_AUTHENTICATION_DELAY = 5
 
     fun ByteArray.toHexString(): String = joinToString(separator = "") { eachByte -> "%02x".format(eachByte) }
 

--- a/app/src/main/kotlin/cloud/keyspace/android/StartHere.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/StartHere.kt
@@ -1702,7 +1702,7 @@ class StartHere : AppCompatActivity() {
                     timeoutDialog.show()
                 } catch (_: WindowManager.BadTokenException) { }
 
-            }, (crypto.DEFAULT_AUTHENTICATION_DELAY - 2).toLong() * 1000)
+            }, (300).toLong() * 1000)
 
 
         } catch (noLockSet: NoSuchMethodError) {

--- a/app/src/main/kotlin/cloud/keyspace/android/StartHere.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/StartHere.kt
@@ -293,7 +293,7 @@ class StartHere : AppCompatActivity() {
                     } catch (activityDead: WindowManager.BadTokenException) {
                     }
 
-                }, (crypto.DEFAULT_AUTHENTICATION_DELAY - 2).toLong() * 1000)
+                }, (300).toLong() * 1000)
 
 
             } catch (noLockSet: NoSuchMethodError) {


### PR DESCRIPTION
- Solves authentication timeout issues mentioned in #6
- Reduces the amount of time keystore is open after successful authentication from 30seconds -> 5 seconds
