### PR TITLE
Username and email display behavior

### DIFF
--- a/app/src/main/kotlin/cloud/keyspace/android/AddLogin.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/AddLogin.kt
@@ -74,8 +74,6 @@ class AddLogin : AppCompatActivity() {
     lateinit var emailInputLayout: TextInputLayout
     lateinit var emailInput: TextInputEditText
 
-    lateinit var emailAsUsername: MaterialSwitch
-
     lateinit var passwordInputLayout: TextInputLayout
     lateinit var passwordInput: TextInputEditText
     lateinit var clearButton: ImageView
@@ -290,14 +288,6 @@ class AddLogin : AppCompatActivity() {
         userNameInput = findViewById (R.id.userNameInput)
         userNameInput.imeOptions = IME_FLAG_NO_PERSONALIZED_LEARNING
         userNameInputLayout = findViewById (R.id.userNameInputLayout)
-        userNameInputLayout.visibility = View.GONE
-
-        emailAsUsername = findViewById (R.id.emailAsUsername)
-        emailAsUsername.isChecked = true
-        emailAsUsername.setOnCheckedChangeListener { _, isChecked ->
-            if (isChecked) userNameInputLayout.visibility = View.GONE
-            else userNameInputLayout.visibility = View.VISIBLE
-        }
 
         emailInput = findViewById (R.id.emailInput)
         emailInput.imeOptions = IME_FLAG_NO_PERSONALIZED_LEARNING
@@ -784,10 +774,6 @@ class AddLogin : AppCompatActivity() {
 
         if (!login.loginData!!.username.isNullOrBlank()) {
             userNameInput.setText(login.loginData.username)
-            emailAsUsername.isChecked = false
-        } else {
-            userNameInputLayout.visibility = View.GONE
-            emailAsUsername.isChecked = true
         }
 
         if (!login.loginData.password.isNullOrEmpty()) {
@@ -984,7 +970,7 @@ class AddLogin : AppCompatActivity() {
             favorite = favorite,
             tagId = tagPicker.getSelectedTagId() ?: tagId,
             loginData = IOUtilities.LoginData(
-                username = if (!emailAsUsername.isChecked) userNameInput.text.toString() else null,
+                username = userNameInput.text.toString(),
                 password = passwordInput.text.toString(),
                 passwordHistory = if (passwordHistoryData.size > 0) passwordHistoryData else null,
                 email = emailInput.text.toString(),

--- a/app/src/main/kotlin/cloud/keyspace/android/AddLogin.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/AddLogin.kt
@@ -984,7 +984,7 @@ class AddLogin : AppCompatActivity() {
             favorite = favorite,
             tagId = tagPicker.getSelectedTagId() ?: tagId,
             loginData = IOUtilities.LoginData(
-                username = userNameInput.text.toString(),
+                username = if (!emailAsUsername.isChecked) userNameInput.text.toString() else null,
                 password = passwordInput.text.toString(),
                 passwordHistory = if (passwordHistoryData.size > 0) passwordHistoryData else null,
                 email = emailInput.text.toString(),

--- a/app/src/main/kotlin/cloud/keyspace/android/Dashboard.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/Dashboard.kt
@@ -1086,7 +1086,9 @@ class Dashboard : AppCompatActivity(), NavigationView.OnNavigationItemSelectedLi
             if (!login.loginData?.email.isNullOrEmpty()) {
                 loginCard.usernameText.text = login.loginData!!.email
                 loginCard.usernameText.setCompoundDrawablesRelativeWithIntrinsicBounds (emailIcon, null, null, null)
-            } else if (!login.loginData?.username.isNullOrEmpty()) {
+            } else loginCard.usernameText.visibility = View.GONE
+
+            if (!login.loginData?.username.isNullOrEmpty()) {
                 loginCard.usernameText.text = login.loginData!!.username
                 loginCard.usernameText.setCompoundDrawablesRelativeWithIntrinsicBounds (loginIcon, null, null, null)
             } else loginCard.usernameText.visibility = View.GONE

--- a/app/src/main/kotlin/cloud/keyspace/android/Dashboard.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/Dashboard.kt
@@ -1086,12 +1086,14 @@ class Dashboard : AppCompatActivity(), NavigationView.OnNavigationItemSelectedLi
             if (!login.loginData?.email.isNullOrEmpty()) {
                 loginCard.usernameText.text = login.loginData!!.email
                 loginCard.usernameText.setCompoundDrawablesRelativeWithIntrinsicBounds (emailIcon, null, null, null)
-            } else loginCard.usernameText.visibility = View.GONE
+            }
 
             if (!login.loginData?.username.isNullOrEmpty()) {
                 loginCard.usernameText.text = login.loginData!!.username
                 loginCard.usernameText.setCompoundDrawablesRelativeWithIntrinsicBounds (loginIcon, null, null, null)
-            } else loginCard.usernameText.visibility = View.GONE
+            }
+
+            if (login.loginData?.username.isNullOrEmpty() && login.loginData?.email.isNullOrEmpty()) loginCard.usernameText.visibility = View.GONE
 
             loginCard.miscText.visibility = View.GONE
 

--- a/app/src/main/res/layout/edit_login.xml
+++ b/app/src/main/res/layout/edit_login.xml
@@ -216,15 +216,6 @@
                         android:inputType="textFilter" />
                 </com.google.android.material.textfield.TextInputLayout>
 
-                <com.google.android.material.materialswitch.MaterialSwitch
-                    android:id="@+id/emailAsUsername"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="15dp"
-                    android:checked="false"
-                    android:text="Use email as username"
-                    app:thumbTint="@color/cardBorderColor" />
-
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="1dp"


### PR DESCRIPTION
## :recycle: Current situation

The existing "Email as username" behavior is confusing. Time to fix that.

## :bulb: Proposed solution

~- Check for "Email as username" state. If checked, set username field to "null" upon item save only (prevents accidental erasure).~
- Remove the "Email as username" switch to:
a. Achieve parity with Keyspace browser plugin(s).
b. Simplify the process of adding a login by preventing unnecessary and confusing options.
- If both email and username are set, prioritize username (helps with sites like reddit).

## 📋 Release Notes

- Changed username-email behavior to prioritize usernames in UI if set.
- Removed the "Email as username" switch

### Testing

- Create a login with username and email and save it and observe the login card: the username is shown in the dashboard card but they're both displayed in the mini login dialog.
- Create a login with an username only and save it. Only the username is shown in both the login card and the mini dialog.
- Create a login with an email only and save it. Only the email is shown in both the login card and the mini dialog.
- Create a login with a name only and save it. Neither the email nor the username is shown in both the login card and the mini dialog.
~- Edit the login, check the "Email as username" switch, save it and observe again.~
