### PR TITLE
Totp length validation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,23 +6,18 @@
 
 *Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?*
 
-## 📷: Screenshots
+## 📷 Screenshots
 
 *Provide screenshots showcasing the changes before and after the proposed changes (if applicable).*
 
-## 📋 : Release Notes
+## 📚 Release Notes
 
 *Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*
 
-
-
-## :heavy_plus_sign: Additional Information
-*If applicable, provide additional context in this section.*
-
-### Testing
+### 📝 Testing
 
 *Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*
 
-### Reviewer Nudging
+### 👉 Reviewer Nudging
 
 *Where should the reviewer start? what is a good entry point?*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,10 +14,7 @@
 
 *Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*
 
-### 📝 Testing
+## 📝 Testing
 
 *Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*
 
-### 👉 Reviewer Nudging
-
-*Where should the reviewer start? what is a good entry point?*

--- a/app/src/main/kotlin/cloud/keyspace/android/AddLogin.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/AddLogin.kt
@@ -195,6 +195,11 @@ class AddLogin : AppCompatActivity() {
                 }
             }
 
+            if (secretInput.text.toString().isNotBlank() && secretInput.text.toString().length < 6) {
+                secretInput.error = "Please enter a valid TOTP secret"
+                return@setOnClickListener
+            }
+
             saveItem()
 
         }
@@ -629,7 +634,7 @@ class AddLogin : AppCompatActivity() {
             override fun afterTextChanged (s: Editable) { }
             override fun beforeTextChanged (s: CharSequence, start: Int, count: Int, after: Int) { }
             override fun onTextChanged (s: CharSequence, start: Int, before: Int, count: Int) {
-                if (s.length >= 8) {
+                if (s.length >= 6) {
                     try {
                         otpCode = GoogleAuthenticator(base32secret = secretInput.text.toString()).generate()
                         runOnUiThread { tokenPreview.text = otpCode!!.replace("...".toRegex(), "$0 ") }


### PR DESCRIPTION
## :recycle: Current situation

TOTPs with extremely short-length secrets (1-5 characters) are displayed inconsistently throughout the app.

## :bulb: Proposed solution

Save a login containing a authenticator secret only if the secret length >= 6 characters. Display a discreet error in the text box otherwise.

Ideally, users copy and paste or scan a QR code to save this information, so the error accounts for an edge case where the user needs to type their secret into the authenticator secret text box.

## 📚 Release Notes

- Reduced minimum authenticator secret length from 8 to 6 throughout app.
- Added an error indicator to the authenticator text box if the secret is too short.

## 📝 Testing

1. Try saving a login where the authenticator secret is in range 1..5.
2. Tap the tick mark and observe the error icon in the authenticator secret text box. 

