### PR TITLE
Revamped Keyspace settings to match Android 13 AOSP settings

### DIFF
--- a/app/src/main/kotlin/cloud/keyspace/android/Settings.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/Settings.kt
@@ -27,6 +27,9 @@ class Settings : AppCompatActivity() {
 
         val configData = getSharedPreferences (applicationContext.packageName + "_configuration_data", MODE_PRIVATE)
 
+        val backButton: ImageView = findViewById(R.id.backButton)
+        backButton.setOnClickListener { onBackPressed() }
+
         val keyspaceAccountPicture: ImageView = findViewById(R.id.keyspaceAccountPicture)
         keyspaceAccountPicture.setImageDrawable(MiscUtilities(applicationContext).generateProfilePicture(configData.getString("userEmail", null)!!))
 
@@ -59,14 +62,14 @@ class Settings : AppCompatActivity() {
         val strongBoxIcon: ImageView = findViewById(R.id.strongBoxTypeIcon)
 
         if (applicationContext.packageManager.hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE)) { // Check if strongbox / hardware keystore exists
-            strongBoxText.text = "Keyspace is encrypting your keys and tokens using tamper-resistant Strongbox hardware on your phone."
+            strongBoxText.text = "Keys are encrypted using tamper-resistant Strongbox hardware."
             strongBoxIcon.setImageDrawable(getDrawable(R.drawable.ic_baseline_chip_24))
         } else {
             if (applicationContext.packageManager.hasSystemFeature(PackageManager.FEATURE_HARDWARE_KEYSTORE)) {
-                strongBoxText.text = "Your phone doesn't contain Strongbox hardware. Using Hardware Abstraction Layer (HAL) based Keystore."
+                strongBoxText.text = "Keys are encrypted using Hardware Abstraction Layer (HAL) Keystore."
                 strongBoxIcon.setImageDrawable(getDrawable(R.drawable.ic_baseline_code_24))
             } else {
-                strongBoxText.text = "Your phone doesn't contain strongbox hardware. Using container-based Keystore."
+                strongBoxText.text = "Keys are encrypted using container-based Keystore."
                 strongBoxIcon.setImageDrawable(getDrawable(R.drawable.ic_baseline_insert_drive_file_24))
             }
         }

--- a/app/src/main/res/layout/developer_options.xml
+++ b/app/src/main/res/layout/developer_options.xml
@@ -20,7 +20,15 @@
             android:layout_height="match_parent"
             android:paddingBottom="50dp"
             android:orientation="vertical"
-            android:paddingTop="105dp">
+            android:paddingTop="15dp">
+
+            <ImageView
+                android:id="@+id/backButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="20dp"
+                app:srcCompat="@drawable/ic_baseline_arrow_back_24"
+                app:tint="?android:attr/textColorPrimary" />
 
             <TextView
                 android:id="@+id/developerOptionsActivityLabelTop"
@@ -28,8 +36,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="25dp"
                 android:layout_marginBottom="20dp"
+                android:layout_marginTop="70dp"
                 android:text="Developer options"
-                android:textSize="32sp" />
+                android:textSize="35sp" />
 
             <LinearLayout
                 android:id="@+id/blake2bSettings"
@@ -54,15 +63,24 @@
                         android:orientation="vertical">
 
                         <TextView
-                            android:id="@+id/blake2bLabel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:duplicateParentState="true"
                             android:paddingStart="5dp"
-                            android:paddingBottom="10dp"
-                            android:text="BLAKE2B tester"
+                            android:paddingTop="25dp"
+                            android:paddingBottom="20dp"
+                            android:text="Cryptography testers"
                             android:textColor="?attr/colorAccent"
                             android:textStyle="bold" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:duplicateParentState="true"
+                            android:layout_height="wrap_content"
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
+                            android:paddingHorizontal="5dp"
+                            android:text="Test BLAKE2B" />
 
                         <TextView
                             android:id="@+id/blake2bDescriptionText"
@@ -102,6 +120,7 @@
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="BLAKE2B hash"
+                                android:layout_marginTop="10dp"
                                 app:icon="@drawable/ic_baseline_root_24" />
 
                         </LinearLayout>
@@ -143,15 +162,13 @@
                         android:orientation="vertical">
 
                         <TextView
-                            android:id="@+id/Argon2iLabel"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
+                            android:layout_width="match_parent"
                             android:duplicateParentState="true"
-                            android:paddingStart="5dp"
-                            android:paddingBottom="10dp"
-                            android:text="Argon2i tester"
-                            android:textColor="?attr/colorAccent"
-                            android:textStyle="bold" />
+                            android:layout_height="wrap_content"
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
+                            android:paddingHorizontal="5dp"
+                            android:text="Test Argon2i" />
 
                         <TextView
                             android:id="@+id/argon2DescriptionText"
@@ -240,6 +257,7 @@
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:text="Argon2i hash"
+                                android:layout_marginTop="10dp"
                                 app:icon="@drawable/ic_baseline_root_24" />
 
                         </LinearLayout>
@@ -280,15 +298,13 @@
                         android:orientation="vertical">
 
                         <TextView
-                            android:id="@+id/bip39Label"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
+                            android:layout_width="match_parent"
                             android:duplicateParentState="true"
-                            android:paddingStart="5dp"
-                            android:paddingBottom="10dp"
-                            android:text="BIP39 tester"
-                            android:textColor="?attr/colorAccent"
-                            android:textStyle="bold" />
+                            android:layout_height="wrap_content"
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
+                            android:paddingHorizontal="5dp"
+                            android:text="Test BIP39" />
 
                         <TextView
                             android:id="@+id/bip39DescriptionText"
@@ -338,6 +354,7 @@
                                     android:layout_height="wrap_content"
                                     android:layout_marginEnd="10dp"
                                     android:text="Generate words"
+                                    android:layout_marginTop="10dp"
                                     app:icon="@drawable/ic_baseline_checklist_24" />
 
 

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -34,7 +34,7 @@
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:layout_gravity="end"
-                android:layout_marginVertical="12dp"
+                android:layout_marginVertical="10dp"
                 android:layout_marginHorizontal="8dp"
                 android:gravity="end"
                 app:strokeColor="@color/cardBorderColor"
@@ -57,7 +57,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="25dp"
-                android:layout_marginBottom="28dp"
+                android:layout_marginBottom="20dp"
                 android:text="Settings"
                 android:textSize="35sp" />
 
@@ -261,9 +261,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:duplicateParentState="true"
-                android:paddingStart="22dp"
-                android:paddingTop="20dp"
-                android:paddingBottom="15dp"
+                android:paddingStart="25dp"
+                android:paddingTop="25dp"
+                android:paddingBottom="10dp"
                 android:text="User Interface"
                 android:textColor="?attr/colorAccent"
                 android:textStyle="bold" />
@@ -277,15 +277,16 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginVertical="10dp"
+                    android:layout_marginVertical="15dp"
+                    android:layout_marginHorizontal="15dp"
                     android:orientation="horizontal">
 
                     <ImageView
                         android:id="@+id/notesGridIcon"
-                        android:layout_width="175dp"
+                        android:layout_width="165dp"
                         android:layout_height="50dp"
                         android:layout_gravity="center"
-                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginHorizontal="10dp"
                         android:layout_weight="1"
                         app:srcCompat="@drawable/ic_baseline_grid_24" />
 
@@ -334,15 +335,16 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginVertical="10dp"
+                    android:layout_marginVertical="15dp"
+                    android:layout_marginHorizontal="15dp"
                     android:orientation="horizontal">
 
                     <ImageView
                         android:id="@+id/notesPreviewIcon"
-                        android:layout_width="175dp"
+                        android:layout_width="165dp"
                         android:layout_height="50dp"
                         android:layout_gravity="center"
-                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginHorizontal="10dp"
                         android:layout_weight="1"
                         app:srcCompat="@drawable/ic_baseline_edit_note_24" />
 
@@ -387,9 +389,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:duplicateParentState="true"
-                android:paddingStart="22dp"
-                android:paddingTop="20dp"
-                android:paddingBottom="15dp"
+                android:paddingStart="25dp"
+                android:paddingTop="25dp"
+                android:paddingBottom="10dp"
                 android:text="Privacy and Security"
                 android:textColor="?attr/colorAccent"
                 android:textStyle="bold" />
@@ -403,18 +405,19 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginVertical="10dp"
+                    android:layout_marginVertical="15dp"
+                    android:layout_marginHorizontal="15dp"
                     android:duplicateParentState="true"
                     android:enabled="false"
                     android:orientation="horizontal">
 
                     <ImageView
                         android:id="@+id/strongBoxIcon"
-                        android:layout_width="175dp"
+                        android:layout_width="150dp"
                         android:duplicateParentState="true"
                         android:layout_height="50dp"
                         android:layout_gravity="center"
-                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginHorizontal="10dp"
                         android:layout_weight="1"
                         app:srcCompat="@drawable/ic_baseline_phonelink_lock_24" />
 
@@ -433,7 +436,7 @@
                             android:paddingVertical="3.5dp"
                             android:textSize="20sp"
                             android:paddingHorizontal="5dp"
-                            android:text="Store data in secure hardware" />
+                            android:text="Use secure hardware" />
 
                         <TextView
                             android:id="@+id/strongBoxText"
@@ -467,15 +470,16 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginVertical="10dp"
+                    android:layout_marginVertical="15dp"
+                    android:layout_marginHorizontal="15dp"
                     android:orientation="horizontal">
 
                     <ImageView
                         android:id="@+id/lockAppIcon"
-                        android:layout_width="175dp"
+                        android:layout_width="165dp"
                         android:layout_height="50dp"
                         android:layout_gravity="center"
-                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginHorizontal="10dp"
                         android:layout_weight="1"
                         app:srcCompat="@drawable/ic_baseline_lock_24" />
 
@@ -523,15 +527,16 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginVertical="10dp"
+                    android:layout_marginVertical="15dp"
+                    android:layout_marginHorizontal="15dp"
                     android:orientation="horizontal">
 
                     <ImageView
                         android:id="@+id/allowScreenshotsIcon"
-                        android:layout_width="175dp"
+                        android:layout_width="165dp"
                         android:layout_height="50dp"
                         android:layout_gravity="center"
-                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginHorizontal="10dp"
                         android:layout_weight="1"
                         app:srcCompat="@drawable/ic_baseline_screenshot_24" />
 
@@ -575,10 +580,10 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:duplicateParentState="true"
-                android:paddingTop="20dp"
-                android:paddingBottom="15dp"
+                android:paddingTop="25dp"
+                android:paddingBottom="10dp"
                 android:textColor="?attr/colorAccent"
-                android:paddingStart="22dp"
+                android:paddingStart="25dp"
                 android:text="Connectivity"
                 android:textStyle="bold" />
 
@@ -591,15 +596,16 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginVertical="10dp"
+                    android:layout_marginVertical="15dp"
+                    android:layout_marginHorizontal="15dp"
                     android:orientation="horizontal">
 
                     <ImageView
                         android:id="@+id/syncIcon"
-                        android:layout_width="95dp"
+                        android:layout_width="70dp"
                         android:layout_height="50dp"
                         android:layout_gravity="center"
-                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginHorizontal="10dp"
                         android:layout_weight="1"
                         app:srcCompat="@drawable/ic_baseline_sync_24" />
 
@@ -674,10 +680,10 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:duplicateParentState="true"
-                android:paddingTop="20dp"
-                android:paddingBottom="15dp"
+                android:paddingTop="25dp"
+                android:paddingBottom="10dp"
                 android:textColor="?attr/colorAccent"
-                android:paddingStart="22dp"
+                android:paddingStart="25dp"
                 android:text="About"
                 android:textStyle="bold" />
 
@@ -690,15 +696,16 @@
                     android:id="@+id/buildVersionLayout"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginVertical="10dp"
+                    android:layout_marginVertical="15dp"
+                    android:layout_marginHorizontal="15dp"
                     android:orientation="horizontal">
 
                     <ImageView
                         android:id="@+id/buildIcon"
-                        android:layout_width="95dp"
+                        android:layout_width="70dp"
                         android:layout_height="50dp"
                         android:layout_gravity="center"
-                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginHorizontal="10dp"
                         android:layout_weight="1"
                         app:srcCompat="@drawable/ic_outline_info_24" />
 
@@ -710,7 +717,7 @@
 
                         <TextView
                             android:id="@+id/buildText"
-                            android:layout_width="match_parent"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:paddingVertical="3.5dp"
                             android:textSize="20sp"
@@ -719,7 +726,7 @@
 
                         <TextView
                             android:id="@+id/buildLabel"
-                            android:layout_width="match_parent"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
                             android:text="Version 0.0" />
@@ -739,15 +746,16 @@
                     android:id="@+id/openSourceLicensesLayout"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginVertical="10dp"
+                    android:layout_marginVertical="15dp"
+                    android:layout_marginHorizontal="15dp"
                     android:orientation="horizontal">
 
                     <ImageView
                         android:id="@+id/openSourceLicensesIcon"
-                        android:layout_width="95dp"
+                        android:layout_width="70dp"
                         android:layout_height="50dp"
                         android:layout_gravity="center"
-                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginHorizontal="10dp"
                         android:layout_weight="1"
                         app:srcCompat="@drawable/ic_baseline_code_24" />
 
@@ -759,7 +767,7 @@
 
                         <TextView
                             android:id="@+id/openSourceLicensesText"
-                            android:layout_width="match_parent"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:paddingVertical="3.5dp"
                             android:textSize="20sp"
@@ -768,7 +776,7 @@
 
                         <TextView
                             android:id="@+id/openSourceLicensesLabel"
-                            android:layout_width="match_parent"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
                             android:text="Tap to view" />
@@ -785,15 +793,17 @@
                 android:layout_height="match_parent"
                 android:orientation="vertical">
 
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginVertical="10dp"
+                    android:layout_marginVertical="15dp"
+                    android:layout_marginHorizontal="15dp"
                     android:orientation="horizontal">
 
                     <ImageView
                         android:id="@+id/keyspacerIcon"
-                        android:layout_width="90dp"
+                        android:layout_width="60dp"
                         android:layout_height="50dp"
                         android:layout_gravity="center"
                         android:layout_marginStart="10dp"
@@ -804,23 +814,21 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:layout_marginHorizontal="18dp"
+                        android:layout_marginHorizontal="15dp"
                         android:orientation="vertical">
 
                         <TextView
                             android:id="@+id/keyspacerText"
-                            android:layout_width="match_parent"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:paddingVertical="3.5dp"
                             android:textSize="20sp"
-                            android:paddingHorizontal="5dp"
                             android:text="Developer options" />
 
                         <TextView
                             android:id="@+id/keyspacerLabel"
-                            android:layout_width="match_parent"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:paddingHorizontal="5dp"
                             android:text="Welcome chad!" />
 
                     </LinearLayout>

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -20,12 +20,21 @@
             android:layout_height="match_parent"
             android:paddingBottom="50dp"
             android:orientation="vertical"
-            android:paddingTop="55dp">
+            android:paddingTop="15dp" >
+
+            <ImageView
+                android:id="@+id/backButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="20dp"
+                app:srcCompat="@drawable/ic_baseline_arrow_back_24"
+                app:tint="?android:attr/textColorPrimary" />
 
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:layout_gravity="end"
+                android:layout_marginVertical="12dp"
                 android:layout_marginHorizontal="8dp"
                 android:gravity="end"
                 app:strokeColor="@color/cardBorderColor"
@@ -48,9 +57,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="25dp"
-                android:layout_marginBottom="20dp"
+                android:layout_marginBottom="28dp"
                 android:text="Settings"
-                android:textSize="32sp" />
+                android:textSize="35sp" />
 
             <!--<TextView
                 android:id="@+id/autofillSettingsCategoryLabel"
@@ -253,7 +262,8 @@
                 android:layout_height="wrap_content"
                 android:duplicateParentState="true"
                 android:paddingStart="22dp"
-                android:paddingTop="10dp"
+                android:paddingTop="20dp"
+                android:paddingBottom="15dp"
                 android:text="User Interface"
                 android:textColor="?attr/colorAccent"
                 android:textStyle="bold" />
@@ -290,16 +300,16 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
-                            android:paddingTop="5dp"
+                            android:paddingVertical="3.5dp"
                             android:text="Display notes in grid"
-                            android:textStyle="bold" />
+                            android:textSize="20sp" />
 
                         <TextView
                             android:id="@+id/notesGridText"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
-                            android:text="Display your notes in a grid format on the Dashboard like sticky notes." />
+                            android:text="Show notes in a grid, like sticky notes." />
                     </LinearLayout>
 
                     <com.google.android.material.materialswitch.MaterialSwitch
@@ -347,16 +357,16 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
-                            android:paddingTop="5dp"
-                            android:text="Instantly edit notes"
-                            android:textStyle="bold" />
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
+                            android:text="Instantly edit notes" />
 
                         <TextView
                             android:id="@+id/notesPreviewText"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
-                            android:text="Tap on a note to directly edit it." />
+                            android:text="Tap a note to directly edit it." />
                     </LinearLayout>
 
                     <com.google.android.material.materialswitch.MaterialSwitch
@@ -374,11 +384,12 @@
 
             <TextView
                 android:id="@+id/privacyAndSecuritySettingsCategoryLabel2"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:duplicateParentState="true"
                 android:paddingStart="22dp"
-                android:paddingTop="10dp"
+                android:paddingTop="20dp"
+                android:paddingBottom="15dp"
                 android:text="Privacy and Security"
                 android:textColor="?attr/colorAccent"
                 android:textStyle="bold" />
@@ -419,10 +430,10 @@
                             android:layout_width="match_parent"
                             android:duplicateParentState="true"
                             android:layout_height="wrap_content"
-                            android:paddingTop="5dp"
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
                             android:paddingHorizontal="5dp"
-                            android:text="Store data in secure hardware"
-                            android:textStyle="bold" />
+                            android:text="Store data in secure hardware" />
 
                         <TextView
                             android:id="@+id/strongBoxText"
@@ -430,7 +441,7 @@
                             android:duplicateParentState="true"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
-                            android:text="Keyspace is encrypting your keys and tokens using tamper-resistant hardware on your phone." />
+                            android:text="Keys are encrypted using tamper-resistant hardware." />
 
                     </LinearLayout>
 
@@ -478,17 +489,17 @@
                             android:id="@+id/lockAppLabel"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:paddingTop="5dp"
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
                             android:paddingHorizontal="5dp"
-                            android:text="Lock app when minimized (unstable)"
-                            android:textStyle="bold" />
+                            android:text="Lock app when minimized (unstable)" />
 
                         <TextView
                             android:id="@+id/lockAppText"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
-                            android:text="Lock the Keyspace app with your biometrics or PIN, pattern or password when you swipe to switch to another app or go home." />
+                            android:text="Lock Keyspace when you switch to another app or go home." />
                     </LinearLayout>
 
                     <com.google.android.material.materialswitch.MaterialSwitch
@@ -534,17 +545,17 @@
                             android:id="@+id/allowScreenshotsLabel"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:paddingTop="5dp"
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
                             android:paddingHorizontal="5dp"
-                            android:text="Allow in-app screenshots"
-                            android:textStyle="bold" />
+                            android:text="Allow in-app screenshots" />
 
                         <TextView
                             android:id="@+id/allowScreenshotsText"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
-                            android:text="Disabling screenshots can prevent you from accidentally screen recording your passwords and such." />
+                            android:text="Prevents you from accidentally capturing sensitive data." />
                     </LinearLayout>
 
                     <com.google.android.material.materialswitch.MaterialSwitch
@@ -564,7 +575,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:duplicateParentState="true"
-                android:paddingTop="10dp"
+                android:paddingTop="20dp"
+                android:paddingBottom="15dp"
                 android:textColor="?attr/colorAccent"
                 android:paddingStart="22dp"
                 android:text="Connectivity"
@@ -599,19 +611,19 @@
 
                         <TextView
                             android:id="@+id/syncLabel"
-                            android:layout_width="match_parent"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:paddingTop="5dp"
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
                             android:paddingHorizontal="5dp"
-                            android:text="Vault refresh interval"
-                            android:textStyle="bold" />
+                            android:text="Vault refresh interval" />
 
                         <TextView
                             android:id="@+id/syncText"
-                            android:layout_width="match_parent"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
-                            android:text="Control how frequently your vault items synchronize with Keyspace servers" />
+                            android:text="Control how frequently Keyspace synchronizes with the backend" />
 
                         <RadioGroup
                             android:id="@+id/intervalButtonGroup"
@@ -662,7 +674,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:duplicateParentState="true"
-                android:paddingTop="10dp"
+                android:paddingTop="20dp"
+                android:paddingBottom="15dp"
                 android:textColor="?attr/colorAccent"
                 android:paddingStart="22dp"
                 android:text="About"
@@ -699,10 +712,10 @@
                             android:id="@+id/buildText"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:paddingTop="5dp"
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
                             android:paddingHorizontal="5dp"
-                            android:text="Build version"
-                            android:textStyle="bold" />
+                            android:text="Build version" />
 
                         <TextView
                             android:id="@+id/buildLabel"
@@ -748,10 +761,10 @@
                             android:id="@+id/openSourceLicensesText"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:paddingTop="5dp"
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
                             android:paddingHorizontal="5dp"
-                            android:text="Open-source license"
-                            android:textStyle="bold" />
+                            android:text="Open-source license" />
 
                         <TextView
                             android:id="@+id/openSourceLicensesLabel"
@@ -798,10 +811,10 @@
                             android:id="@+id/keyspacerText"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:paddingTop="5dp"
+                            android:paddingVertical="3.5dp"
+                            android:textSize="20sp"
                             android:paddingHorizontal="5dp"
-                            android:text="Developer options"
-                            android:textStyle="bold" />
+                            android:text="Developer options" />
 
                         <TextView
                             android:id="@+id/keyspacerLabel"

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -629,7 +629,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="5dp"
-                            android:text="Control how frequently Keyspace synchronizes with the backend" />
+                            android:text="Control how frequently Keyspace synchronizes your vault with the server." />
 
                         <RadioGroup
                             android:id="@+id/intervalButtonGroup"

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -622,7 +622,7 @@
                             android:paddingVertical="3.5dp"
                             android:textSize="20sp"
                             android:paddingHorizontal="5dp"
-                            android:text="Vault refresh interval" />
+                            android:text="Vault sync" />
 
                         <TextView
                             android:id="@+id/syncText"


### PR DESCRIPTION
## :recycle: Current situation

The Keyspace settings menu UI seemed like a mix of Material 1.0, Material 2.0 and Material 3.0. It needs to be update to match the design language of the rest of the app.

## :bulb: Proposed solution

Update Keyspace settings using AOSP system settings as reference.

## 📷 Screenshots

| **Old**  | **New**  | 
|---|---|
|  ![Old Keyspace settings](https://user-images.githubusercontent.com/71916237/215348365-43f9ddc0-d7cc-4745-be76-33c762819413.png) | ![New Keyspace settings](https://user-images.githubusercontent.com/71916237/215348210-723a673a-76e5-4dd4-ba93-7a18ea8c7f96.png)  | 

## 📚 Release Notes

- Added a back button to the top right corner of the screen
- Updated Keyspace settings using AOSP system settings as reference.
- Made text bigger and increased margin in several places

## 📝 Testing

- Tap the back button on the top right to go back. This behavior is identical to tapping a navigation bar button on the bottom or swiping from left or right edge of the screen to go back.

