### PR TITLE
added 5 digit card PIN support

### DIFF
--- a/app/src/main/kotlin/cloud/keyspace/android/AddCard.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/AddCard.kt
@@ -388,7 +388,7 @@ class AddCard : AppCompatActivity() {
         if (cardNumberInput.text.toString().replace(" ", "").length < 16) cardNumberInput.error = "Enter a valid 16 digit card number"
         else if (cardNumberInput.text.toString().replace(" ", "").length in 17..18
             || cardNumberInput.text.toString().replace(" ", "").length > 19) cardNumberInput.error = "Enter a valid 19 digit card number"
-        else if (securityCode.text.toString().length !in 3..4) securityCode.error = "Enter a valid security code"
+        else if (securityCode.text.toString().length !in 3..5) securityCode.error = "Enter a valid security code"
         else if (toDate.text.toString().isEmpty()) toDate.error = "Enter an expiry date"
         else if (cardholderNameInput.text.toString().isEmpty()) cardholderNameInput.error = "Enter card holder's name"
         else if (nameInput.text.toString().isEmpty()) nameInput.error = "Enter a name. This can be your bank's name."

--- a/app/src/main/kotlin/cloud/keyspace/android/AddCard.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/AddCard.kt
@@ -388,11 +388,11 @@ class AddCard : AppCompatActivity() {
         if (cardNumberInput.text.toString().replace(" ", "").length < 16) cardNumberInput.error = "Enter a valid 16 digit card number"
         else if (cardNumberInput.text.toString().replace(" ", "").length in 17..18
             || cardNumberInput.text.toString().replace(" ", "").length > 19) cardNumberInput.error = "Enter a valid 19 digit card number"
-        else if (securityCode.text.toString().length !in 3..5) securityCode.error = "Enter a valid security code"
+        else if (securityCode.text.toString().length !in 3..4) securityCode.error = "Enter a valid security code"
         else if (toDate.text.toString().isEmpty()) toDate.error = "Enter an expiry date"
         else if (cardholderNameInput.text.toString().isEmpty()) cardholderNameInput.error = "Enter card holder's name"
         else if (nameInput.text.toString().isEmpty()) nameInput.error = "Enter a name. This can be your bank's name."
-        else if (isAtmCard.isChecked && atmPinInput.text.toString().length < 4) atmPinInput.error = "Enter a valid Personal Identification Number"
+        else if (isAtmCard.isChecked && atmPinInput.text.toString().length !in 4..6) atmPinInput.error = "Enter a valid Personal Identification Number"
 
         else {
 
@@ -411,7 +411,7 @@ class AddCard : AppCompatActivity() {
                 cardholderName = cardholderNameInput.text.toString(),
                 expiry = toDate.text.toString(),
                 notes = notesInput.text.toString(),
-                pin = if (atmPinInput.text.toString().length == 4 && isAtmCard.isChecked) atmPinInput.text.toString() else "",
+                pin = if (atmPinInput.text.toString().length == 4 && isAtmCard.isChecked) atmPinInput.text.toString() else null,
                 securityCode = securityCode.text.toString(),
                 customFields = customFieldsData,
                 rfid = hasRfidChip.isChecked,

--- a/app/src/main/res/layout/edit_card.xml
+++ b/app/src/main/res/layout/edit_card.xml
@@ -278,7 +278,7 @@
                             android:fontFamily="monospace"
                             android:inputType="none|phone"
                             android:letterSpacing="0.05"
-                            android:maxLength="4" />
+                            android:maxLength="5" />
 
                     </com.google.android.material.textfield.TextInputLayout>
                 </LinearLayout>

--- a/app/src/main/res/layout/edit_card.xml
+++ b/app/src/main/res/layout/edit_card.xml
@@ -278,7 +278,7 @@
                             android:fontFamily="monospace"
                             android:inputType="none|phone"
                             android:letterSpacing="0.05"
-                            android:maxLength="5" />
+                            android:maxLength="4" />
 
                     </com.google.android.material.textfield.TextInputLayout>
                 </LinearLayout>
@@ -346,7 +346,7 @@
                             android:digits="0123456789"
                             android:fontFamily="monospace"
                             android:inputType="none|phone"
-                            android:maxLength="4" />
+                            android:maxLength="6" />
 
                     </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
## :recycle: Current situation

5 digit ATM PINs are not supported. ATMs in some countries use 4, 5 and 6 digit PINs. Example: https://support.weswap.com/hc/en-gb/articles/4409801993361-The-ATM-is-asking-for-a-5-or-6-digits-PIN-what-do-I-do-

## :bulb: Proposed solution

Add support for it.

## 📷 Screenshots

Overkill

## 📚 Release Notes

- Added support for 5 digit ATM PIN in `EditText`
- Added 4 to 5 digit ATM PIN validation to `AddCard.kt`

## 📝 Testing

- Try adding a 5 digit PIN
- Notice that you can.
