### PR TITLE
bumped sync timer to 5500

### DIFF
--- a/app/src/main/kotlin/cloud/keyspace/android/Dashboard.kt
+++ b/app/src/main/kotlin/cloud/keyspace/android/Dashboard.kt
@@ -3156,7 +3156,7 @@ class Dashboard : AppCompatActivity(), NavigationView.OnNavigationItemSelectedLi
         }
 
         if (refreshInterval != -1L) {
-            if (refreshInterval == 0L) refreshInterval = 3000L
+            if (refreshInterval == 0L) refreshInterval = 5500L
             vaultSyncTimer.scheduleAtFixedRate(object : TimerTask() {
                 override fun run() {
                     runOnUiThread {


### PR DESCRIPTION
## :recycle: Current situation

The network call timer thread executed too frequently, causing Volley to suffer from a memory leak from inconclusive requests.

## :bulb: Proposed solution

Increase the timer interval to 5500ms.

## 📷 Screenshots

NA

## 📚 Release Notes

- Changed the timer interval to 5500ms.

## 📝 Testing

- Start the Keyspace app, make sure your vault has entries.
- Keep the app open for 15 minutes and check if the app is still up and running in the foreground.
- Tell me if it crashes or not in the comments.

